### PR TITLE
Execute need promises sequentially in order to guarantee the correct state of the store.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -90,7 +90,7 @@ app.use((req, res) => {
 
     const store = configureStore(initialState);
 
-    fetchComponentData(store.dispatch, renderProps.components, renderProps.params)
+    fetchComponentData(store, renderProps.components, renderProps.params)
       .then(() => {
         const initialView = renderToString(
           <Provider store={store}>

--- a/server/util/fetchData.js
+++ b/server/util/fetchData.js
@@ -1,11 +1,12 @@
 /* This was inspired from https://github.com/caljrimmer/isomorphic-redux-app/blob/73e6e7d43ccd41e2eb557a70be79cebc494ee54b/src/common/api/fetchComponentDataBeforeRender.js */
+import { sequence } from './promiseUtils';
 
-export function fetchComponentData(dispatch, components, params) {
+export function fetchComponentData(store, components, params) {
   const needs = components.reduce((prev, current) => {
     return (current.need || [])
       .concat((current.WrappedComponent && (current.WrappedComponent.need !== current.need) ? current.WrappedComponent.need : []) || [])
       .concat(prev);
   }, []);
-  const promises = needs.map(need => dispatch(need(params)));
-  return Promise.all(promises);
+
+  return sequence(needs, need => store.dispatch(need(params, store.getState())));
 }

--- a/server/util/promiseUtils.js
+++ b/server/util/promiseUtils.js
@@ -1,0 +1,21 @@
+/** 
+ * Throw an array to it and a function which can generate promises
+ * and it will call them sequentially, one after another
+ */
+export function sequence(items, consumer) {
+  let results = [];
+  let runner = () => {
+    let item = items.shift();
+    if (item) {
+      return consumer(item)
+        .then((result) => {
+          results.push(result);
+        })
+        .then(runner);
+    }
+
+    return Promise.resolve(results);
+  };
+
+  return runner();
+};


### PR DESCRIPTION
Whenever I use mern.io I have cases where I need to have the state of the store in the `need` function, and be able to have the latest state after the previous `need` is executed:

```
LoginValidation.need = [(params, state) => {
    return Actions.getUserSession(state.sessionToken);
}];
```

after that in deeper component:

```
UserProfile.need = [(params, state) => {
   return Actions.getUserPages(state.userSession.id);
}];
```

To do this, i had to change the fetchData to use my own `sequence` function, which would execute promises in sequence, one after another, in order to guarantee the latest state of the store in the `need` function. I`v also changed the server.js to pass the store instead of only dispatch method.

This solution I'm currently using in my own project and decided to make it publicly available, maybe someone also will need it.

Change is not breaking.