### PR TITLE
fixes #101 fall through next middleware if route not found

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -76,14 +76,18 @@ const renderFullPage = (html, initialState) => {
 };
 
 // Server Side Rendering based on routes matched by React-router.
-app.use((req, res) => {
+app.use((req, res, next) => {
   match({ routes, location: req.url }, (err, redirectLocation, renderProps) => {
     if (err) {
       return res.status(500).end('Internal server error');
     }
-
+    
+    if (redirectLocation) {
+      return res.redirect(302, redirectLocation.pathname + redirectLocation.search);
+    }
+    
     if (!renderProps) {
-      return res.status(404).end('Not found!');
+      return next();
     }
 
     const initialState = { posts: [], post: {} };


### PR DESCRIPTION
Just in case someone wants to add some extra middleware after this one.
Express will take care of issuing the 404 Not found message.

Also, deals with redirection as per router documentation.
https://github.com/reactjs/react-router-redux/blob/master/examples/server/server.js#L46

Also, if I don't know what a callback would do with the return, I prefer to do `return void next()`.  In this case, though, it is safe since react-router doesn't care, but I had to check it out.  Simpler to add the `void` and be safe.

(linted and test and test:server)