### PR TITLE
fix reducer hot module replacement

### DIFF
--- a/shared/redux/store/configureStore.js
+++ b/shared/redux/store/configureStore.js
@@ -22,7 +22,7 @@ export function configureStore(initialState = {}) {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers/reducer', () => {
-      const nextReducer = require('../reducers/reducer');
+      const nextReducer = require('../reducers/reducer').default;
       store.replaceReducer(nextReducer);
     });
   }


### PR DESCRIPTION
`export default` in ES6 Modules is transformed to `module.exports.default` in CommonJS , so to get the right export by using `require('something').default` instead of `require('something')`