### PR TITLE
catch render errors on the serverside

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -111,7 +111,8 @@ app.use((req, res, next) => {
         const finalState = store.getState();
 
         res.status(200).end(renderFullPage(initialView, finalState));
-      });
+      })
+      .catch((err) => next(err));
   });
 });
 


### PR DESCRIPTION
My browser timed out (maybe related to #140) because reacts `renderToString` failed and the response was never sent. It now catches react render errors and sends them further down the pipe to the express handler. It's basic and the server handles a failing request successfully but we sould come up with a better solution/tools for server side error handling during development.