### PR TITLE
Set Content-Type header of prerendered HTML response

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -115,7 +115,10 @@ app.use((req, res, next) => {
         );
         const finalState = store.getState();
 
-        res.status(200).end(renderFullPage(initialView, finalState));
+        res
+          .set('Content-Type', 'text/html')
+          .status(200)
+          .end(renderFullPage(initialView, finalState));
       })
       .catch((err) => next(err));
   });


### PR DESCRIPTION
W3c validator complained and therefore would not validate:
The Content-Type was null. Using the XML parser (not resolving external entities).
