### PR TITLE
Set Content-Type header of prerendered HTML response

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -113,7 +113,10 @@ app.use((req, res, next) => {
         );
         const finalState = store.getState();
 
-        res.status(200).end(renderFullPage(initialView, finalState));
+        res
+          .set('Content-Type', 'text/html')
+          .status(200)
+          .end(renderFullPage(initialView, finalState));
       })
       .catch((error) => next(error));
   });


### PR DESCRIPTION
> W3C threw me an error when having a `<p>` element inside `react-typewriter` so I'd like to propose to change the container to be a `<div>` since it may have any element as a child.

Same as https://github.com/ianbjorndilling/react-typewriter/pull/17 but against the v2.0.0 branch.