### PR TITLE
Add and implement compression module in order to gzip all request to express

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "babel-core": "^6.9.1",
     "body-parser": "^1.15.1",
+    "compression": "^1.6.2",
     "cross-env": "^1.0.8",
     "cuid": "^1.3.8",
     "express": "^4.13.4",

--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,5 @@
 import Express from 'express';
+import compression from 'compression';
 import mongoose from 'mongoose';
 import bodyParser from 'body-parser';
 import path from 'path';
@@ -46,6 +47,7 @@ mongoose.connect(serverConfig.mongoURL, (error) => {
 });
 
 // Apply body Parser and server public assets and routes
+app.use(compression());
 app.use(bodyParser.json({ limit: '20mb' }));
 app.use(bodyParser.urlencoded({ limit: '20mb', extended: false }));
 app.use(Express.static(path.resolve(__dirname, '../dist')));


### PR DESCRIPTION
I guess it is arguable whether compression should be used for all environments or only for production. I would be happy to add a commit to implement this if this would be desirable.