### PR TITLE
fix client side mismatch markup

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -3,10 +3,7 @@
  */
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Router, browserHistory } from 'react-router';
-
-// Import Routes
-import routes from './routes';
+import { Router } from 'react-router';
 
 // Base stylesheet
 require('./main.css');
@@ -14,13 +11,12 @@ require('./main.css');
 export default function App(props) {
   return (
     <Provider store={props.store}>
-      <Router history={browserHistory}>
-        {routes}
-      </Router>
+      <Router {...props.renderProps} />
     </Provider>
   );
 }
 
 App.propTypes = {
   store: React.PropTypes.object.isRequired,
+  renderProps: React.PropTypes.object.isRequired,
 };

--- a/client/index.js
+++ b/client/index.js
@@ -6,17 +6,24 @@ import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 import App from './App';
 import { configureStore } from './store';
+import { browserHistory } from 'react-router';
+import { match } from 'react-router';
+
+// Import Routes
+import routes from './routes';
 
 // Initialize store
 const store = configureStore(window.__INITIAL_STATE__);
 const mountApp = document.getElementById('root');
 
-render(
-  <AppContainer>
-    <App store={store} />
-  </AppContainer>,
-  mountApp
-);
+match({ history: browserHistory, routes }, (error, redirectLocation, renderProps) => {
+  render(
+    <AppContainer>
+      <App store={store} renderProps={renderProps} />
+    </AppContainer>,
+    mountApp
+  );
+});
 
 // For hot reloading of react components
 if (module.hot) {
@@ -24,11 +31,13 @@ if (module.hot) {
     // If you use Webpack 2 in ES modules mode, you can
     // use <App /> here rather than require() a <NextApp />.
     const NextApp = require('./App').default; // eslint-disable-line global-require
-    render(
-      <AppContainer>
-        <NextApp store={store} />
-      </AppContainer>,
-      mountApp
-    );
+    match({ history: browserHistory, routes }, (error, redirectLocation, renderProps) => {
+      render(
+        <AppContainer>
+          <NextApp store={store} renderProps={renderProps} />
+        </AppContainer>,
+        mountApp
+      );
+    })
   });
 }


### PR DESCRIPTION
This PR fixes #149

Worth knowing
DEVELOPMENT ONLY: there is now a little delay in the injection of webpack style blobs ( i think match delays the code execution, i'll investigate about that) thus the styles are applied a bit later and sometimes this is noticeable but this is only happening is development mode, in production the styles are injected as a link tag at render time.