### PR TITLE
Adding react-intl

### DIFF
--- a/client/modules/App/App.js
+++ b/client/modules/App/App.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { IntlProvider } from 'react-intl';
 
 // Import Style
 import styles from './App.css';
@@ -29,31 +30,33 @@ class App extends Component {
 
   render() {
     return (
-      <div>
-        {this.state.isMounted && !window.devToolsExtension && <DevTools />}
+      <IntlProvider {...this.props.intl}>
         <div>
-          <Helmet
-            title="MERN Starter - Blog App"
-            titleTemplate="%s - Blog App"
-            meta={[
-              { charset: 'utf-8' },
-              {
-                'http-equiv': 'X-UA-Compatible',
-                content: 'IE=edge',
-              },
-              {
-                name: 'viewport',
-                content: 'width=device-width, initial-scale=1',
-              },
-            ]}
-          />
-          <Header toggleAddPost={this.toggleAddPostSection} />
-          <div className={styles.container}>
-            {this.props.children}
+          {this.state.isMounted && !window.devToolsExtension && <DevTools />}
+          <div>
+            <Helmet
+              title="MERN Starter - Blog App"
+              titleTemplate="%s - Blog App"
+              meta={[
+                { charset: 'utf-8' },
+                {
+                  'http-equiv': 'X-UA-Compatible',
+                  content: 'IE=edge',
+                },
+                {
+                  name: 'viewport',
+                  content: 'width=device-width, initial-scale=1',
+                },
+              ]}
+            />
+            <Header toggleAddPost={this.toggleAddPostSection} />
+            <div className={styles.container}>
+              {this.props.children}
+            </div>
+            <Footer />
           </div>
-          <Footer />
         </div>
-      </div>
+      </IntlProvider>
     );
   }
 }
@@ -61,6 +64,9 @@ class App extends Component {
 App.propTypes = {
   children: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
-export default connect()(App);
+export default connect(store => ({
+  intl: store.intl,
+}))(App);

--- a/client/modules/Intl/IntlActions.js
+++ b/client/modules/Intl/IntlActions.js
@@ -1,3 +1,4 @@
+import { addLocaleData } from 'react-intl';
 
 // Export Constants
 export const SWITCH_LANGUAGES = 'SWITCH_LANGUAGES';
@@ -10,3 +11,35 @@ export function switchLanguages(newLang) {
     fields: {},
   };
 }
+
+export const enabledLanguages = [
+  'en',
+  'ar',
+  'es',
+  'fr',
+];
+
+// here you bring in 'intl' browser polyfill and language-specific polyfills
+// (needed as safari doesn't have native intl: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
+// as well as react-intl's language-specific date
+// be sure to use static imports or else every language will be included in your build
+
+// need Intl polyfill, Intl not supported in Safari
+import Intl from 'intl';
+global.Intl = Intl;
+
+import 'intl/locale-data/jsonp/en';
+import en from 'react-intl/locale-data/en';
+addLocaleData(en);
+
+import 'intl/locale-data/jsonp/ar';
+import ar from 'react-intl/locale-data/ar';
+addLocaleData(ar);
+
+import 'intl/locale-data/jsonp/es';
+import es from 'react-intl/locale-data/es';
+addLocaleData(es);
+
+import 'intl/locale-data/jsonp/fr';
+import fr from 'react-intl/locale-data/fr';
+addLocaleData(fr);

--- a/client/modules/Intl/IntlActions.js
+++ b/client/modules/Intl/IntlActions.js
@@ -1,4 +1,4 @@
-import { addLocaleData } from 'react-intl';
+import { localizationData } from './setup/setup';
 
 // Export Constants
 export const SWITCH_LANGUAGES = 'SWITCH_LANGUAGES';
@@ -6,40 +6,6 @@ export const SWITCH_LANGUAGES = 'SWITCH_LANGUAGES';
 export function switchLanguages(newLang) {
   return {
     type: SWITCH_LANGUAGES,
-    locale: newLang,
-    messages: {},
-    fields: {},
+    ...localizationData[newLang],
   };
 }
-
-export const enabledLanguages = [
-  'en',
-  'ar',
-  'es',
-  'fr',
-];
-
-// here you bring in 'intl' browser polyfill and language-specific polyfills
-// (needed as safari doesn't have native intl: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
-// as well as react-intl's language-specific date
-// be sure to use static imports or else every language will be included in your build
-
-// need Intl polyfill, Intl not supported in Safari
-import Intl from 'intl';
-global.Intl = Intl;
-
-import 'intl/locale-data/jsonp/en';
-import en from 'react-intl/locale-data/en';
-addLocaleData(en);
-
-import 'intl/locale-data/jsonp/ar';
-import ar from 'react-intl/locale-data/ar';
-addLocaleData(ar);
-
-import 'intl/locale-data/jsonp/es';
-import es from 'react-intl/locale-data/es';
-addLocaleData(es);
-
-import 'intl/locale-data/jsonp/fr';
-import fr from 'react-intl/locale-data/fr';
-addLocaleData(fr);

--- a/client/modules/Intl/IntlActions.js
+++ b/client/modules/Intl/IntlActions.js
@@ -1,0 +1,12 @@
+
+// Export Constants
+export const SWITCH_LANGUAGES = 'SWITCH_LANGUAGES';
+
+export function switchLanguages(newLang) {
+  return {
+    type: SWITCH_LANGUAGES,
+    locale: newLang,
+    messages: {},
+    fields: {},
+  };
+}

--- a/client/modules/Intl/IntlReducer.js
+++ b/client/modules/Intl/IntlReducer.js
@@ -1,10 +1,12 @@
-import { SWITCH_LANGUAGES, enabledLanguages } from './IntlActions';
+import { enabledLanguages, localizationData } from './setup/setup';
+import { SWITCH_LANGUAGES } from './IntlActions';
+
+const initLocale = global.navigator && global.navigator.language || 'en';
 
 const initialState = {
-  locale: 'en',
-  messages: {},
-  fields: {},
+  locale: initLocale,
   enabledLanguages,
+  ...(localizationData[initLocale] || {}),
 };
 
 const IntlReducer = (state = initialState, { type, ...action }) => {

--- a/client/modules/Intl/IntlReducer.js
+++ b/client/modules/Intl/IntlReducer.js
@@ -1,10 +1,10 @@
-import { SWITCH_LANGUAGES } from './IntlActions';
+import { SWITCH_LANGUAGES, enabledLanguages } from './IntlActions';
 
 const initialState = {
   locale: 'en',
   messages: {},
   fields: {},
-  enabledLanguages: ['en', 'fr'],
+  enabledLanguages,
 };
 
 const IntlReducer = (state = initialState, { type, ...action }) => {

--- a/client/modules/Intl/IntlReducer.js
+++ b/client/modules/Intl/IntlReducer.js
@@ -1,0 +1,20 @@
+import { SWITCH_LANGUAGES } from './IntlActions';
+
+const initialState = {
+  locale: 'en',
+  messages: {},
+  fields: {},
+  enabledLanguages: ['en', 'fr'],
+};
+
+const IntlReducer = (state = initialState, { type, ...action }) => {
+  switch (type) {
+    case SWITCH_LANGUAGES:
+      return { ...state, ...action };
+
+    default:
+      return state;
+  }
+};
+
+export default IntlReducer;

--- a/client/modules/Intl/pages/Demo/Demo.js
+++ b/client/modules/Intl/pages/Demo/Demo.js
@@ -65,8 +65,11 @@ export default injectIntl(connect(store => ({
           Formatted Date
         </h2>
           {
-            dateArr.map((date) =>
-              <div className="FormattedDate">
+            dateArr.map((date, i) =>
+              <div
+                className="FormattedDate"
+                key={i}
+              >
                 <FormattedDate
                   value={date}
                   day="numeric"
@@ -81,8 +84,11 @@ export default injectIntl(connect(store => ({
           Formatted Time
         </h2>
           {
-            timeArr.map((time) =>
-              <div className="FormattedTime">
+            timeArr.map((time, i) =>
+              <div
+                className="FormattedTime"
+                key={i}
+              >
                 <FormattedTime
                   value={time}
                   hour12
@@ -97,8 +103,11 @@ export default injectIntl(connect(store => ({
           Formatted Relative Date
         </h2>
           {
-            dateArr.map((date) =>
-              <div className="FormattedRelativeDate">
+            dateArr.map((date, i) =>
+              <div
+                className="FormattedRelativeDate"
+                key={i}
+              >
                 <FormattedRelative value={date} />
               </div>
             )
@@ -108,8 +117,11 @@ export default injectIntl(connect(store => ({
           Formatted Number
         </h2>
           {
-            numberArr.map((number) =>
-              <div className="FormattedNumber">
+            numberArr.map((number, i) =>
+              <div
+                className="FormattedNumber"
+                key={i}
+              >
                 <FormattedNumber value={number} /> {' '}
               </div>
             )
@@ -123,7 +135,10 @@ export default injectIntl(connect(store => ({
         </h2>
           {
             numberArr.map((_, i) =>
-              <div className="FormattedPlural">
+              <div
+                className="FormattedPlural"
+                key={i}
+              >
                 You have {' '}
                 <FormattedPlural
                   value={i + 1}
@@ -139,7 +154,10 @@ export default injectIntl(connect(store => ({
         </h2>
           {
             numberArr.map((_, i) =>
-              <div className="FormattedMessage">
+              <div
+                className="FormattedMessage"
+                key={i}
+              >
                 <FormattedMessage
                   id="comment"
                   defaultMessage="Hello, {name}"
@@ -159,7 +177,10 @@ export default injectIntl(connect(store => ({
         </h2>
           {
             numberArr.map((_, i) =>
-              <div className="FormattedHTMLMessage">
+              <div
+                className="FormattedHTMLMessage"
+                key={i}
+              >
                 <FormattedHTMLMessage
                   id="HTMLComment"
                   defaultMessage="Hello, {name}"
@@ -178,7 +199,10 @@ export default injectIntl(connect(store => ({
         </h2>
           {
             numberArr.map((_, i) =>
-              <div className="NestedFormattedMessage">
+              <div
+                className="NestedFormattedMessage"
+                key={i}
+              >
                 <FormattedMessage
                   id="nestedDateComment"
                   defaultMessage="Hello, {name}"

--- a/client/modules/Intl/pages/Demo/Demo.js
+++ b/client/modules/Intl/pages/Demo/Demo.js
@@ -1,0 +1,202 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { injectIntl, FormattedDate, FormattedTime, FormattedRelative, FormattedNumber, FormattedMessage, FormattedPlural, FormattedHTMLMessage } from 'react-intl';
+import { switchLanguages } from '../../IntlActions';
+
+export default injectIntl(connect(store => ({
+  intl: store.intl,
+}))(class LanguageDemoPage extends Component {
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.changeLanguage = (o) => {
+      const clickedLang = o.target.innerText;
+      if (clickedLang !== this.props.intl.locale) this.props.dispatch(switchLanguages(clickedLang));
+    };
+  }
+
+  render() {
+    const dateArr = [
+      Date.now() + 1000 * 60 * 60 * 24 * 15,  // fifteenDaysFromNow
+      Date.now() + 1000 * 60 * 51,            // tomorrow
+      Date.now(),                             // currentDate
+      Date.now() - 1000 * 60 * 60 * 24,       // yesterday
+      Date.now() - 1000 * 60 * 60 * 24 * 15,  // fifteenDaysAgo
+    ];
+
+    const timeArr = [
+      Date.now() + 1000 * 60 * 60,            // hourFromNow
+      Date.now() + 1000 * 60,                 // minuteFromNow
+      Date.now(),                             // now
+      Date.now() - 1000 * 60,                 // minuteAgo
+      Date.now() - 1000 * 60 * 60,            // hourAgo
+    ];
+
+    const numberArr = [
+      1,                                      // one
+      5,                                      // plural
+      3.14152927,                             // decimal
+      -4,                                     // negative
+      1000000,                                // large
+    ];
+
+    const userName = 'Example UserName';
+
+    return (
+      <div className="Language-Examples">
+        <header className="Language-Toggles">
+          {this.props.intl.enabledLanguages.map((languageOption, i) =>
+            <a
+              href="#"
+              key={i}
+              style={{ padding: '1px 5px', marginLeft: '5px' }}
+              onClick={this.changeLanguage}
+            >
+              {languageOption}
+            </a>
+          )}
+        </header>
+
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Formatted Date
+        </h2>
+          {
+            dateArr.map((date) =>
+              <div className="FormattedDate">
+                <FormattedDate
+                  value={date}
+                  day="numeric"
+                  month="long"
+                  year="numeric"
+                />
+              </div>
+            )
+          }
+
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Formatted Time
+        </h2>
+          {
+            timeArr.map((time) =>
+              <div className="FormattedTime">
+                <FormattedTime
+                  value={time}
+                  hour12
+                  hour="numeric"
+                  minute="numeric"
+                />
+              </div>
+            )
+          }
+
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Formatted Relative Date
+        </h2>
+          {
+            dateArr.map((date) =>
+              <div className="FormattedRelativeDate">
+                <FormattedRelative value={date} />
+              </div>
+            )
+          }
+
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Formatted Number
+        </h2>
+          {
+            numberArr.map((number) =>
+              <div className="FormattedNumber">
+                <FormattedNumber value={number} /> {' '}
+              </div>
+            )
+          }
+
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Formatted Plural
+          <span style={{ fontSize: '14px', fontWeight: 'bold' }}>
+            (Cant use with different languages, showing just to show full component list)
+          </span>
+        </h2>
+          {
+            numberArr.map((_, i) =>
+              <div className="FormattedPlural">
+                You have {' '}
+                <FormattedPlural
+                  value={i + 1}
+                  one="one message"
+                  other="multiple messages"
+                />.
+              </div>
+            )
+          }
+
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Formatted Message
+        </h2>
+          {
+            numberArr.map((_, i) =>
+              <div className="FormattedMessage">
+                <FormattedMessage
+                  id="comment"
+                  defaultMessage="Hello, {name}"
+                  values={
+                    {
+                      name: userName,
+                      value: i,
+                    }
+                  }
+                />
+              </div>
+            )
+          }
+
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Formatted HTML Message
+        </h2>
+          {
+            numberArr.map((_, i) =>
+              <div className="FormattedHTMLMessage">
+                <FormattedHTMLMessage
+                  id="HTMLComment"
+                  defaultMessage="Hello, {name}"
+                  values={
+                    {
+                      name: userName,
+                      value: i,
+                    }
+                  }
+                />
+              </div>
+            )
+          }
+        <h2 style={{ padding: '10px 0 1px', lineHeight: 'inherit' }}>
+          Nested Formatted Message
+        </h2>
+          {
+            numberArr.map((_, i) =>
+              <div className="NestedFormattedMessage">
+                <FormattedMessage
+                  id="nestedDateComment"
+                  defaultMessage="Hello, {name}"
+                  values={
+                    {
+                      name: userName,
+                      value: i,
+                      date: (
+                        <FormattedRelative value={dateArr[i]} />
+                      ),
+                    }
+                  }
+                />
+              </div>
+            )
+          }
+      </div>
+    );
+  }
+}));

--- a/client/modules/Intl/pages/Demo/Demo.js
+++ b/client/modules/Intl/pages/Demo/Demo.js
@@ -51,14 +51,13 @@ export default injectIntl(connect(store => ({
       <div className="Language-Examples">
         <header className="Language-Toggles">
           {this.props.intl.enabledLanguages.map((languageOption, i) =>
-            <a
-              href="#"
+            <button
               key={i}
               style={{ padding: '1px 5px', marginLeft: '5px' }}
               onClick={this.changeLanguage}
             >
               {languageOption}
-            </a>
+            </button>
           )}
         </header>
 

--- a/client/modules/Intl/setup/localizationData/ar.js
+++ b/client/modules/Intl/setup/localizationData/ar.js
@@ -1,0 +1,20 @@
+export default {
+  locale: 'ar',
+  messages: {
+    comment: `user {name} {value, plural,
+    	  =0 {does not have any comments}
+    	  =1 {has # comment}
+    	  other {has # comments}
+    	} (in real app this would be translated to Armenian)`,
+    HTMLComment: `user <b style='font-weight: bold'>{name} </b> {value, plural,
+    	  =0 {does not have <i style='font-style: italic'>any</i> comments}
+    	  =1 {has <i style='font-style: italic'>#</i> comment}
+    	  other {has <i style='font-style: italic'>#</i> comments}
+    	} (in real app this would be translated to Armenian)`,
+    nestedDateComment: `user {name} {value, plural,
+    	  =0 {does not have any comments}
+    	  =1 {has # comment}
+    	  other {has # comments}
+    	} as of {date} (in real app this would be translated to Armenian)`,
+  },
+};

--- a/client/modules/Intl/setup/localizationData/en.js
+++ b/client/modules/Intl/setup/localizationData/en.js
@@ -1,0 +1,20 @@
+export default {
+  locale: 'en',
+  messages: {
+    comment: `user {name} {value, plural,
+    	  =0 {does not have any comments}
+    	  =1 {has # comment}
+    	  other {has # comments}
+    	}`,
+    HTMLComment: `user <b style='font-weight: bold'>{name} </b> {value, plural,
+    	  =0 {does not have <i style='font-style: italic'>any</i> comments}
+    	  =1 {has <i style='font-style: italic'>#</i> comment}
+    	  other {has <i style='font-style: italic'>#</i> comments}
+    	}`,
+    nestedDateComment: `user {name} {value, plural,
+    	  =0 {does not have any comments}
+    	  =1 {has # comment}
+    	  other {has # comments}
+    	} as of {date}`,
+  },
+};

--- a/client/modules/Intl/setup/localizationData/es.js
+++ b/client/modules/Intl/setup/localizationData/es.js
@@ -1,0 +1,20 @@
+export default {
+  locale: 'es',
+  messages: {
+    comment: `user {name} {value, plural,
+    	  =0 {does not have any comments}
+    	  =1 {has # comment}
+    	  other {has # comments}
+    	} (in real app this would be translated to Spanish)`,
+    HTMLComment: `user <b style='font-weight: bold'>{name} </b> {value, plural,
+    	  =0 {does not have <i style='font-style: italic'>any</i> comments}
+    	  =1 {has <i style='font-style: italic'>#</i> comment}
+    	  other {has <i style='font-style: italic'>#</i> comments}
+    	} (in real app this would be translated to Spanish)`,
+    nestedDateComment: `user {name} {value, plural,
+    	  =0 {does not have any comments}
+    	  =1 {has # comment}
+    	  other {has # comments}
+    	} as of {date} (in real app this would be translated to Spanish)`,
+  },
+};

--- a/client/modules/Intl/setup/localizationData/fr.js
+++ b/client/modules/Intl/setup/localizationData/fr.js
@@ -1,0 +1,20 @@
+export default {
+  locale: 'fr',
+  messages: {
+    comment: `user {name} {value, plural,
+    	  =0 {does not have any comments}
+    	  =1 {has # comment}
+    	  other {has # comments}
+    	} (in real app this would be translated to French)`,
+    HTMLComment: `user <b style='font-weight: bold'>{name} </b> {value, plural,
+    	  =0 {does not have <i style='font-style: italic'>any</i> comments}
+    	  =1 {has <i style='font-style: italic'>#</i> comment}
+    	  other {has <i style='font-style: italic'>#</i> comments}
+    	} (in real app this would be translated to French)`,
+    nestedDateComment: `user {name} {value, plural,
+  		  =0 {does not have any comments}
+  		  =1 {has # comment}
+  		  other {has # comments}
+  		} as of {date} (in real app this would be translated to French)`,
+  },
+};

--- a/client/modules/Intl/setup/setup.js
+++ b/client/modules/Intl/setup/setup.js
@@ -1,0 +1,67 @@
+// list of available languages
+export const enabledLanguages = [
+  'en',
+  'ar',
+  'es',
+  'fr',
+];
+
+// this object will have language-specific data added to it which will be placed in the state when that language is active
+// if localization data get to big, stop importing in all languages and switch to using API requests to load upon switching languages
+export const localizationData = {};
+
+// here you bring in 'intl' browser polyfill and language-specific polyfills
+// (needed as safari doesn't have native intl: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
+// as well as react-intl's language-specific data
+// be sure to use static imports for language or else every language will be included in your build (adds ~800 kb)
+import { addLocaleData } from 'react-intl';
+
+// need Intl polyfill, Intl not supported in Safari
+import Intl from 'intl';
+global.Intl = Intl;
+
+// use this to allow nested messages, taken from docs:
+// https://github.com/yahoo/react-intl/wiki/Upgrade-Guide#flatten-messages-object
+function flattenMessages(nestedMessages = {}, prefix = '') {
+  return Object.keys(nestedMessages).reduce((messages, key) => {
+    const value = nestedMessages[key];
+    const prefixedKey = prefix ? `${prefix}.${key}` : key;
+
+    if (typeof value === 'string') {
+      messages[prefixedKey] = value; // eslint-disable-line no-param-reassign
+    } else {
+      Object.assign(messages, flattenMessages(value, prefixedKey));
+    }
+
+    return messages;
+  }, {});
+}
+
+// bring in intl polyfill, react-intl, and app-specific language data
+import 'intl/locale-data/jsonp/en';
+import en from 'react-intl/locale-data/en';
+import enData from './localizationData/en';
+addLocaleData(en);
+localizationData.en = enData;
+localizationData.en.messages = flattenMessages(localizationData.en.messages);
+
+import 'intl/locale-data/jsonp/ar';
+import ar from 'react-intl/locale-data/ar';
+import arData from './localizationData/ar';
+addLocaleData(ar);
+localizationData.ar = arData;
+localizationData.ar.messages = flattenMessages(localizationData.ar.messages);
+
+import 'intl/locale-data/jsonp/es';
+import es from 'react-intl/locale-data/es';
+import esData from './localizationData/es';
+addLocaleData(es);
+localizationData.es = esData;
+localizationData.es.messages = flattenMessages(localizationData.es.messages);
+
+import 'intl/locale-data/jsonp/fr';
+import fr from 'react-intl/locale-data/fr';
+import frData from './localizationData/fr';
+addLocaleData(fr);
+localizationData.fr = frData;
+localizationData.fr.messages = flattenMessages(localizationData.fr.messages);

--- a/client/reducers.js
+++ b/client/reducers.js
@@ -6,9 +6,11 @@ import { combineReducers } from 'redux';
 // Import Reducers
 import app from './modules/App/AppReducer';
 import posts from './modules/Post/PostReducer';
+import intl from './modules/Intl/IntlReducer';
 
 // Combine all reducers into one root reducer
 export default combineReducers({
   app,
   posts,
+  intl
 });

--- a/client/routes.js
+++ b/client/routes.js
@@ -39,5 +39,13 @@ export default (
         });
       }}
     />
+    <Route
+      path="/intl"
+      getComponent={(nextState, cb) => {
+        require.ensure([], require => {
+          cb(null, require('./modules/Intl/pages/Demo/Demo').default);
+        });
+      }}
+    />
   </Route>
 );

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-helmet": "^3.1.0",
+    "react-intl": "^2.1.2",
     "react-redux": "^4.4.5",
     "react-router": "^2.4.1",
     "redux": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cross-env": "^1.0.8",
     "cuid": "^1.3.8",
     "express": "^4.13.4",
+    "intl": "^1.2.4",
     "isomorphic-fetch": "^2.2.1",
     "limax": "^1.3.0",
     "mongoose": "^4.4.20",


### PR DESCRIPTION
Hey dudes,

Went ahead and added React-Intl, didn't see where anyone had done this, it's a bit hairy to work with but pretty awesome once it's up and running.

Visit '/intl' route to check it out in action.

The native Intl package has some basic translations of numbers and dates included I believe (needs to be polyfilled for Safari, took care of that).

React-Intl includes a bunch of additional convenient translations for you, such as relative dates (e.g. yesterday, two weeks from now) as well as a convenient way to plug in your own locale-specific translations for page content, see '/modules/Intl/setup/localizationData/'.

**One bug that's happening now that I can't figure out:**  I get this error message saying 'server-side render discarded'.  No idea what's causing this, probably something small.  I figured one of you might know and then we can fix that and merge this furrealz (feel free to style and integrate as you choose, I never use bootstrap and am not sure how you want user "flow" to be so I pretty much just plopped every React-Intl element on a page haha).

Best,
Rodge