### PR TITLE
Get rid of the router error message while hot reloading

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -16,7 +16,10 @@ export default function App(props) {
   return (
     <Provider store={props.store}>
       <IntlWrapper>
-        <Router history={browserHistory}>
+        <Router
+          history={browserHistory}
+          key={process.env.NODE_ENV === 'development' ? Math.random() : false}
+        >
           {routes}
         </Router>
       </IntlWrapper>


### PR DESCRIPTION
Simple hack to get rid of the error message that occurs while hot reloading.