### PR TITLE
fixed "Warning: React attempted to reuse markup in a container..."error

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -80,7 +80,7 @@ const renderFullPage = (html, initialState) => {
         <link rel="shortcut icon" href="http://res.cloudinary.com/hashnode/image/upload/v1455629445/static_imgs/mern/mern-favicon-circle-fill.png" type="image/png" />
       </head>
       <body>
-        <div id="root">${html}</div>
+        <div id="root"><div>${html}<div></div>
         <script>
           window.__INITIAL_STATE__ = ${JSON.stringify(initialState)};
           ${process.env.NODE_ENV === 'production' ?


### PR DESCRIPTION
I was getting this warning in the console: 
'Warning: React attempted to reuse markup in a container but the checksum was invalid.' 

Double wrapping the html injection in `<div>` tags removes this error.
