### PR TITLE
Eliminate different markup warning between client/server during dev

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -84,7 +84,7 @@ const renderFullPage = (html, initialState) => {
         <link rel="shortcut icon" href="http://res.cloudinary.com/hashnode/image/upload/v1455629445/static_imgs/mern/mern-favicon-circle-fill.png" type="image/png" />
       </head>
       <body>
-        <div id="root">${html}</div>
+        <div id="root">${process.env.NODE_ENV === 'production' ? html : `<div>${html}</div>`}</div>
         <script>
           window.__INITIAL_STATE__ = ${JSON.stringify(initialState)};
           ${isProdMode ?


### PR DESCRIPTION
This was a recommended fix in https://github.com/Hashnode/mern-starter/issues/149. Works as expected. I think it could be pulled into master instead of stringing it through the new version branches and waiting until down the road.

Let me know what you think @mannyhenri
